### PR TITLE
Try supporting custom ITIL Object types

### DIFF
--- a/js/stab.js
+++ b/js/stab.js
@@ -23,9 +23,9 @@ $(document).ready(function() {
    const ajax_url = CFG_GLPI.root_doc+"/"+GLPI_PLUGINS_PATH.stab+"/ajax/status.php";
 
    $(document).on('click', '.timeline-buttons .main-actions .answer-action', (e) => {
-      const target_form = $($(e.target).closest('button,a').data('bs-target'));
-      const valid_forms = ['new-ITILFollowup-block','new-TicketTask-block','new-ChangeTask-block','new-ProblemTask-block'];
-      if (!valid_forms.includes(target_form.attr('id'))) {
+      const target_form = $($(e.target).closest('button,a').data('bs-target'))
+      const valid_forms = [/^new-\S+Followup-block$/,/^new-\S+Task-blockS/];
+      if (!valid_forms.some((regex) => regex.test(target_form.attr('id')))) {
          return;
       }
       const parent_itemtype = target_form.find('input[name="itemtype"]').val();

--- a/setup.php
+++ b/setup.php
@@ -25,12 +25,18 @@ define('PLUGIN_STAB_MIN_GLPI', '10.0.0');
 define('PLUGIN_STAB_MAX_GLPI', '10.1.0');
 
 function plugin_init_stab() {
-   global $PLUGIN_HOOKS;
+   global $PLUGIN_HOOKS, $CFG_GLPI;
 
    $PLUGIN_HOOKS['csrf_compliant']['stab'] = true;
 
    if (Plugin::isPluginActive('stab') && !isCommandLine()) {
-      $timeline_pages = ['/front/ticket.form.php', '/front/change.form.php', '/front/problem.form.php'];
+       /** @var class-string<CommonITILObject>[] $itil_types */
+      $itil_types = isset($CFG_GLPI['itil_types']) ? $CFG_GLPI['itil_types'] : ['Ticket', 'Change', 'Problem'];
+      $timeline_pages = [];
+      /** @var class-string<CommonITILObject> $itil_type */
+       foreach ($itil_types as $itil_type) {
+         $timeline_pages[] = $itil_type::getFormURL(false);
+      }
       $url = strtok($_SERVER["REQUEST_URI"], '?');
       foreach ($timeline_pages as $page) {
          if (str_ends_with($url, $page)) {


### PR DESCRIPTION
This PR makes the logic for loading the JS and identifying applicable forms more generic to try adding support for custom ITIL Object types (like ones added by plugins).

For this to work properly for custom types, they will need to add their itemtype to `$CFG_GLPI['itil_types]` which is only in GLPI 10.1.0 currently or manually load this plugin's JS when the requested URL is their custom type's form URL.