### PR TITLE
fix display of pending reason controls

### DIFF
--- a/js/stab.js
+++ b/js/stab.js
@@ -182,6 +182,10 @@ $(document).ready(function() {
                </ul>
             </div>
          `);
+
+         // Fix pending reason control display (instead of width 100%, it should be flex-grow: 1)
+         target_form.find('.card-footer > .input-group').css('flex-grow', '1').css('width', 'auto');
+
          const action_item_list = target_form.find('.card-footer .split-action-items');
          $(itil_status_opts[parent_itemtype]).each((i, o) => {
             action_item_list.append(`


### PR DESCRIPTION
Fixes #10.

A change in GLPI 10.0.9 changed the display of the pending reason controls and added a CSS rule to make its width 100% instead of simply using `flex-grow: 1`, so it was always displaying on a separate line when this plugin re-added the status selection dropdown.